### PR TITLE
Update to Time.cpp

### DIFF
--- a/Time/Time.cpp
+++ b/Time/Time.cpp
@@ -294,7 +294,12 @@ void setTime(int hr,int min,int sec,int dy, int mnth, int yr){
   tm.Hour = hr;
   tm.Minute = min;
   tm.Second = sec;
-  setTime(makeTime(tm));
+
+  //We're setting cacheTime so it's all consistent with tm because the two are linked. Check how refreshCache() works to see.
+  cacheTime = makeTime(tm);
+  
+  setTime(cacheTime);  
+  
 }
 
 void adjustTime(long adjustment) {


### PR DESCRIPTION
This is a fix to a bug I found by luck. This change ensures that if someone had called year(x) before calling setTime(y) and then calls year(x) again, they get their expected value, rather then the one the tm was adjusted to.